### PR TITLE
Increase DEFAULT_CHUNK_SIZE to reduce transfer overhead

### DIFF
--- a/google-cloud-core/src/main/java/com/google/cloud/BaseWriteChannel.java
+++ b/google-cloud-core/src/main/java/com/google/cloud/BaseWriteChannel.java
@@ -36,8 +36,8 @@ public abstract class BaseWriteChannel<
         ServiceOptionsT extends ServiceOptions<?, ServiceOptionsT>, EntityT extends Serializable>
     implements WriteChannel {
 
-  private static final int MIN_CHUNK_SIZE = 256 * 1024;
-  private static final int DEFAULT_CHUNK_SIZE = 8 * MIN_CHUNK_SIZE;
+  private static final int MIN_CHUNK_SIZE = 256 * 1024; // 256 KiB
+  private static final int DEFAULT_CHUNK_SIZE = 60 * MIN_CHUNK_SIZE; // 15MiB
 
   private final ServiceOptionsT options;
   private final EntityT entity;

--- a/google-cloud-core/src/test/java/com/google/cloud/BaseWriteChannelTest.java
+++ b/google-cloud-core/src/test/java/com/google/cloud/BaseWriteChannelTest.java
@@ -55,8 +55,8 @@ public class BaseWriteChannelTest {
   private static final Serializable ENTITY = 42L;
   private static final String UPLOAD_ID = "uploadId";
   private static final byte[] CONTENT = {0xD, 0xE, 0xA, 0xD};
-  private static final int MIN_CHUNK_SIZE = 256 * 1024;
-  private static final int DEFAULT_CHUNK_SIZE = 8 * MIN_CHUNK_SIZE;
+  private static final int MIN_CHUNK_SIZE = 256 * 1024; // 256 KiB
+  private static final int DEFAULT_CHUNK_SIZE = 60 * MIN_CHUNK_SIZE; // 15MiB
   private static final Random RANDOM = new Random();
   private static BaseWriteChannel channel;
 


### PR DESCRIPTION
Fixes #86 by setting the DEFAULT_CHUNK_SIZE to 15MiB.

