### PR TITLE
fix: stop using internal gRPC classes

### DIFF
--- a/google-cloud-core-grpc/pom.xml
+++ b/google-cloud-core-grpc/pom.xml
@@ -48,10 +48,6 @@
       <artifactId>grpc-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
     </dependency>

--- a/google-cloud-core-grpc/src/main/java/com/google/cloud/grpc/GrpcTransportOptions.java
+++ b/google-cloud-core-grpc/src/main/java/com/google/cloud/grpc/GrpcTransportOptions.java
@@ -95,8 +95,7 @@ public class GrpcTransportOptions implements TransportOptions {
                 service.setRemoveOnCancelPolicy(true);
                 return service;
               }
-            }
-        );
+            });
 
     @Override
     public ScheduledExecutorService get() {

--- a/google-cloud-core-grpc/src/test/java/com/google/cloud/grpc/GrpcTransportOptionsTest.java
+++ b/google-cloud-core-grpc/src/test/java/com/google/cloud/grpc/GrpcTransportOptionsTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.grpc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -63,8 +64,12 @@ public class GrpcTransportOptionsTest {
 
   @Test
   public void testDefaultExecutorFactory() {
-    ExecutorFactory<ScheduledExecutorService> executorFactory = new DefaultExecutorFactory();
+    DefaultExecutorFactory executorFactory = new DefaultExecutorFactory();
     ScheduledExecutorService executorService = executorFactory.get();
     assertSame(executorService, executorFactory.get());
+
+    // releasing should close and clear the cached executor service
+    executorFactory.release(executorService);
+    assertNotSame(executorService, executorFactory.get());
   }
 }


### PR DESCRIPTION
`SharedResourceHolder` is essentially a thread-safe, lazy-initializing, singleton registry for any `Resource` (something that can be shutdown/closed). When the resource is closed, they next time it's requested, it should initialize a new instance that is cached anew.

We use guava's `Supplier` (switch to Java 8's implementation when Java support is dropped) interface for lazy-loading and memoization. The `DefaultExecutorFactory` synchronizes on itself for `get()` and `release()` to maintain it's refcount. If the refcount reaches 0, we shutdown the executor.

Fixes #120 