### PR TITLE
fix: Timestamp.of(java.sql.Timestamp) pre-epoch on exact second

### DIFF
--- a/google-cloud-core/src/main/java/com/google/cloud/Timestamp.java
+++ b/google-cloud-core/src/main/java/com/google/cloud/Timestamp.java
@@ -122,9 +122,9 @@ public final class Timestamp implements Comparable<Timestamp>, Serializable {
     int nanos = timestamp.getNanos();
 
     // A pre-epoch timestamp can be off by one second because of the way that integer division
-    // works. For example, -1001 / 1000 == -1. In this case of timestamps, we want this result to be
-    // -2. This causes any pre-epoch timestamp to be off by 1 second - fix this by adjusting the
-    // seconds value by 1 if the timestamp < 0 and the division by 1000 has a remainder.
+    // works. For example, -1001 / 1000 == -1. In this case, we want this result to be -2. This
+    // causes any pre-epoch timestamp to be off by 1 second - fix this by subtracting 1 from the
+    // seconds value if the seconds value is less than zero and is not divisible by 1000.
     // TODO: replace with Math.floorDiv when we drop Java 7 support
     long seconds = timestamp.getTime() / 1000;
     if (seconds < 0 && timestamp.getTime() % 1000 != 0) {

--- a/google-cloud-core/src/main/java/com/google/cloud/Timestamp.java
+++ b/google-cloud-core/src/main/java/com/google/cloud/Timestamp.java
@@ -121,7 +121,7 @@ public final class Timestamp implements Comparable<Timestamp>, Serializable {
   public static Timestamp of(java.sql.Timestamp timestamp) {
     int nanos = timestamp.getNanos();
 
-    // A pre-epoch timestamp could be off by one second because of the way that integer division
+    // A pre-epoch timestamp can be off by one second because of the way that integer division
     // works. For example, -1001 / 1000 == -1. In this case of timestamps, we want this result to be
     // -2. This causes any pre-epoch timestamp to be off by 1 second - fix this by adjusting the
     // seconds value by 1 if the timestamp < 0 and the division by 1000 has a remainder.

--- a/google-cloud-core/src/main/java/com/google/cloud/Timestamp.java
+++ b/google-cloud-core/src/main/java/com/google/cloud/Timestamp.java
@@ -121,13 +121,13 @@ public final class Timestamp implements Comparable<Timestamp>, Serializable {
   public static Timestamp of(java.sql.Timestamp timestamp) {
     int nanos = timestamp.getNanos();
 
-    // A pre-epoch timestamp will be off by one second because of the way that integer division
+    // A pre-epoch timestamp could be off by one second because of the way that integer division
     // works. For example, -1001 / 1000 == -1. In this case of timestamps, we want this result to be
     // -2. This causes any pre-epoch timestamp to be off by 1 second - fix this by adjusting the
-    // seconds value by 1 if the timestamp < 0.
+    // seconds value by 1 if the timestamp < 0 and the division by 1000 has a remainder.
     // TODO: replace with Math.floorDiv when we drop Java 7 support
     long seconds = timestamp.getTime() / 1000;
-    if (seconds < 0) {
+    if (seconds < 0 && timestamp.getTime() % 1000 != 0) {
       --seconds;
     }
 

--- a/google-cloud-core/src/test/java/com/google/cloud/TimestampTest.java
+++ b/google-cloud-core/src/test/java/com/google/cloud/TimestampTest.java
@@ -82,11 +82,11 @@ public class TimestampTest {
   }
 
   @Test
-  public void ofSqlTimestamp() {
+  public void testOf() {
     String expectedTimestampString = "1970-01-01T00:00:12.345000000Z";
     java.sql.Timestamp input = new java.sql.Timestamp(12345);
     Timestamp timestamp = Timestamp.of(input);
-    assertThat(timestamp.toString()).isEqualTo(expectedTimestampString);
+    assertEquals(timestamp.toString(), expectedTimestampString);
   }
 
   @Test
@@ -98,15 +98,15 @@ public class TimestampTest {
   }
 
   @Test
-  public void ofSqlTimestampPreEpoch() {
+  public void testOf_preEpoch() {
     String expectedTimestampString = "1969-12-31T23:59:47.655000000Z";
     java.sql.Timestamp input = new java.sql.Timestamp(-12345);
     Timestamp timestamp = Timestamp.of(input);
-    assertThat(timestamp.toString()).isEqualTo(expectedTimestampString);
+    assertEquals(timestamp.toString(), expectedTimestampString);
   }
 
   @Test
-  public void ofSqlTimestampOnEpoch() {
+  public void testOf_onEpoch() {
     String expectedTimestampString = "1970-01-01T00:00:00Z";
     java.sql.Timestamp input = new java.sql.Timestamp(0);
     Timestamp timestamp = Timestamp.of(input);
@@ -118,7 +118,7 @@ public class TimestampTest {
     String expectedTimestampString = "1969-12-31T23:59:59Z";
     java.sql.Timestamp input = new java.sql.Timestamp(-1000);
     Timestamp timestamp = Timestamp.of(input);
-    assertThat(timestamp.toString()).isEqualTo(expectedTimestampString);
+    assertEquals(timestamp.toString(), expectedTimestampString);
   }
 
   @Test

--- a/google-cloud-core/src/test/java/com/google/cloud/TimestampTest.java
+++ b/google-cloud-core/src/test/java/com/google/cloud/TimestampTest.java
@@ -89,7 +89,7 @@ public class TimestampTest {
   }
 
   @Test
-  public void ofSqlTimestampOnExactSecond() {
+  public void testOf_exactSecond() {
     String expectedTimestampString = "1970-01-01T00:00:12Z";
     java.sql.Timestamp input = new java.sql.Timestamp(12000);
     Timestamp timestamp = Timestamp.of(input);
@@ -113,7 +113,7 @@ public class TimestampTest {
   }
 
   @Test
-  public void ofSqlTimestampPreEpochOnExactSecond() {
+  public void testOf_preEpochExactSecond() {
     String expectedTimestampString = "1969-12-31T23:59:59Z";
     java.sql.Timestamp input = new java.sql.Timestamp(-1000);
     Timestamp timestamp = Timestamp.of(input);

--- a/google-cloud-core/src/test/java/com/google/cloud/TimestampTest.java
+++ b/google-cloud-core/src/test/java/com/google/cloud/TimestampTest.java
@@ -18,6 +18,7 @@ package com.google.cloud;
 
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.google.common.testing.EqualsTester;
@@ -93,7 +94,7 @@ public class TimestampTest {
     String expectedTimestampString = "1970-01-01T00:00:12Z";
     java.sql.Timestamp input = new java.sql.Timestamp(12000);
     Timestamp timestamp = Timestamp.of(input);
-    assertThat(timestamp.toString()).isEqualTo(expectedTimestampString);
+    assertEquals(timestamp.toString(), expectedTimestampString);
   }
 
   @Test
@@ -109,7 +110,7 @@ public class TimestampTest {
     String expectedTimestampString = "1970-01-01T00:00:00Z";
     java.sql.Timestamp input = new java.sql.Timestamp(0);
     Timestamp timestamp = Timestamp.of(input);
-    assertThat(timestamp.toString()).isEqualTo(expectedTimestampString);
+    assertEquals(timestamp.toString(), expectedTimestampString);
   }
 
   @Test

--- a/google-cloud-core/src/test/java/com/google/cloud/TimestampTest.java
+++ b/google-cloud-core/src/test/java/com/google/cloud/TimestampTest.java
@@ -89,6 +89,14 @@ public class TimestampTest {
   }
 
   @Test
+  public void ofSqlTimestampOnExactSecond() {
+    String expectedTimestampString = "1970-01-01T00:00:12Z";
+    java.sql.Timestamp input = new java.sql.Timestamp(12000);
+    Timestamp timestamp = Timestamp.of(input);
+    assertThat(timestamp.toString()).isEqualTo(expectedTimestampString);
+  }
+
+  @Test
   public void ofSqlTimestampPreEpoch() {
     String expectedTimestampString = "1969-12-31T23:59:47.655000000Z";
     java.sql.Timestamp input = new java.sql.Timestamp(-12345);
@@ -100,6 +108,14 @@ public class TimestampTest {
   public void ofSqlTimestampOnEpoch() {
     String expectedTimestampString = "1970-01-01T00:00:00Z";
     java.sql.Timestamp input = new java.sql.Timestamp(0);
+    Timestamp timestamp = Timestamp.of(input);
+    assertThat(timestamp.toString()).isEqualTo(expectedTimestampString);
+  }
+
+  @Test
+  public void ofSqlTimestampPreEpochOnExactSecond() {
+    String expectedTimestampString = "1969-12-31T23:59:59Z";
+    java.sql.Timestamp input = new java.sql.Timestamp(-1000);
     Timestamp timestamp = Timestamp.of(input);
     assertThat(timestamp.toString()).isEqualTo(expectedTimestampString);
   }


### PR DESCRIPTION
The fix for negative timestamps in https://github.com/googleapis/java-core/pull/160 did not take into account the possibility that the pre-epoch timestamp could be on an exact second value. In that case, the additional correction of the calculated second value should not be applied.

Fixes https://github.com/googleapis/java-spanner-jdbc/issues/85