### PR TITLE
deps: rely on shared-config for auto-value configuration

### DIFF
--- a/google-cloud-core-grpc/pom.xml
+++ b/google-cloud-core-grpc/pom.xml
@@ -66,10 +66,5 @@
       <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.objenesis</groupId>
-      <artifactId>objenesis</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/google-cloud-core-http/pom.xml
+++ b/google-cloud-core-http/pom.xml
@@ -84,11 +84,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.objenesis</groupId>
-      <artifactId>objenesis</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
       <scope>test</scope>

--- a/google-cloud-core/pom.xml
+++ b/google-cloud-core/pom.xml
@@ -83,11 +83,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.objenesis</groupId>
-      <artifactId>objenesis</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-core-parent</site.installationModule>
-    <auto-value.version>1.7</auto-value.version>
     <gax.version>1.56.0</gax.version>
     <google.api-common.version>1.9.0</google.api-common.version>
     <google.common-protos.version>1.18.0</google.common-protos.version>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,6 @@
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-core-parent</site.installationModule>
     <auto-value.version>1.7</auto-value.version>
-    <auto-value-annotations.version>1.7</auto-value-annotations.version>
     <gax.version>1.56.0</gax.version>
     <google.api-common.version>1.9.0</google.api-common.version>
     <google.common-protos.version>1.18.0</google.common-protos.version>
@@ -231,12 +230,6 @@
         <version>${guava.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.auto.value</groupId>
-        <artifactId>auto-value-annotations</artifactId>
-        <version>${auto-value-annotations.version}</version>
-        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
@@ -318,33 +311,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <configuration>
-            <ignoredUnusedDeclaredDependencies>org.objenesis:objenesis</ignoredUnusedDeclaredDependencies>
-          </configuration>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <annotationProcessorPaths>
-              <path>
-                <groupId>com.google.auto.value</groupId>
-                <artifactId>auto-value</artifactId>
-                <version>${auto-value.version}</version>
-              </path>
-            </annotationProcessorPaths>
-          </configuration>
-        </plugin>
-      </plugins>
-
-    </pluginManagement>
-  </build>
 
   <modules>
     <module>google-cloud-core</module>


### PR DESCRIPTION
Allows use of shared configuration for auto-value and will keep auto-value versions in sync