### PR TITLE
chore: ignore samples presubmits

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -21,5 +21,6 @@ AUTOSYNTH_MULTIPLE_COMMITS = True
 java.common_templates(excludes=[
   'README.md',
   'samples/*',
+  '.github/workflows/samples.yaml',
 ])
 


### PR DESCRIPTION
This repo does not have samples so skip the samples presubmit checks.