### PR TITLE
feat: support downloading an emulator from an access controlled URL

### DIFF
--- a/google-cloud-core/src/main/java/com/google/cloud/testing/BaseEmulatorHelper.java
+++ b/google-cloud-core/src/main/java/com/google/cloud/testing/BaseEmulatorHelper.java
@@ -38,6 +38,7 @@ import java.math.BigInteger;
 import java.net.HttpURLConnection;
 import java.net.ServerSocket;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
@@ -316,6 +317,7 @@ public abstract class BaseEmulatorHelper<T extends ServiceOptions> {
     private final String md5CheckSum;
     private final URL downloadUrl;
     private final String fileName;
+    private String accessToken;
     private Process process;
     private static final Logger log = Logger.getLogger(DownloadableEmulatorRunner.class.getName());
 
@@ -326,6 +328,12 @@ public abstract class BaseEmulatorHelper<T extends ServiceOptions> {
       this.downloadUrl = downloadUrl;
       String[] splitUrl = downloadUrl.toString().split("/");
       this.fileName = splitUrl[splitUrl.length - 1];
+    }
+
+    public DownloadableEmulatorRunner(
+            List<String> commandText, URL downloadUrl, String md5CheckSum, String accessToken) {
+      this(commandText, downloadUrl, md5CheckSum);
+      this.accessToken = accessToken;
     }
 
     @Override
@@ -420,7 +428,11 @@ public abstract class BaseEmulatorHelper<T extends ServiceOptions> {
         if (log.isLoggable(Level.FINE)) {
           log.fine("Fetching emulator");
         }
-        ReadableByteChannel rbc = Channels.newChannel(downloadUrl.openStream());
+        URLConnection urlConnection = downloadUrl.openConnection();
+        if (accessToken != null) {
+          urlConnection.setRequestProperty("Authorization", "Bearer " + accessToken);
+        }
+        ReadableByteChannel rbc = Channels.newChannel(urlConnection.getInputStream());
         try (FileOutputStream fos = new FileOutputStream(zipFile)) {
           fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
         }

--- a/google-cloud-core/src/main/java/com/google/cloud/testing/BaseEmulatorHelper.java
+++ b/google-cloud-core/src/main/java/com/google/cloud/testing/BaseEmulatorHelper.java
@@ -331,7 +331,7 @@ public abstract class BaseEmulatorHelper<T extends ServiceOptions> {
     }
 
     public DownloadableEmulatorRunner(
-            List<String> commandText, URL downloadUrl, String md5CheckSum, String accessToken) {
+        List<String> commandText, URL downloadUrl, String md5CheckSum, String accessToken) {
       this(commandText, downloadUrl, md5CheckSum);
       this.accessToken = accessToken;
     }

--- a/google-cloud-core/src/test/java/com/google/cloud/testing/BaseEmulatorHelperTest.java
+++ b/google-cloud-core/src/test/java/com/google/cloud/testing/BaseEmulatorHelperTest.java
@@ -108,6 +108,7 @@ public class BaseEmulatorHelperTest {
     String mockInputStream = "mockInputStream";
     String mockProtocol = "mockProtocol";
     String mockFile = "mockFile";
+    String mockAccessToken = "mockAccessToken";
     String mockCommandText = "mockCommandText";
 
     MockURLStreamHandler mockURLStreamHandler = EasyMock.createMock(MockURLStreamHandler.class);
@@ -119,6 +120,7 @@ public class BaseEmulatorHelperTest {
     EasyMock.expect(mockURLConnection.getInputStream())
         .andReturn(new ByteArrayInputStream(mockInputStream.getBytes()))
         .anyTimes();
+    mockURLConnection.setRequestProperty("Authorization", "Bearer " + mockAccessToken);
     EasyMock.expect(mockURLStreamHandler.openConnection(EasyMock.anyObject(URL.class)))
         .andThrow(new EOFException())
         .times(1);
@@ -130,7 +132,7 @@ public class BaseEmulatorHelperTest {
     URL url = new URL(mockProtocol, null, 0, mockFile, mockURLStreamHandler);
     BaseEmulatorHelper.DownloadableEmulatorRunner runner =
         new BaseEmulatorHelper.DownloadableEmulatorRunner(
-            ImmutableList.of(mockCommandText), url, null);
+            ImmutableList.of(mockCommandText), url, null, mockAccessToken);
 
     File cachedFile = new File(System.getProperty("java.io.tmpdir"), mockExternalForm);
     cachedFile.delete(); // Clear the cached version so we're always testing the download


### PR DESCRIPTION
Fixes googleapis/java-datastore#376
used in googleapis/java-datastore#492