### PR TITLE
fix(java): add missing build-time configurations for native-image support

### DIFF
--- a/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-core/native-image.properties
+++ b/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-core/native-image.properties
@@ -1,6 +1,7 @@
 Args = --allow-incomplete-classpath \
 --enable-url-protocols=https,http \
---initialize-at-build-time=org.conscrypt \
+--initialize-at-build-time=org.conscrypt,\
+  org.slf4j.LoggerFactory \
 --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.SSL,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifier,\


### PR DESCRIPTION
This PR adds some missing configurations for native-image build. 

Running `mvn test -Pnative` locally for [googleapis/java-bigquerystorage](https://github.com/googleapis/java-bigquerystorage) is resulting in the following error message:

```
Error: Classes that should be initialized at run time got initialized during image building:
 org.slf4j.LoggerFactory was unintentionally initialized at build time. To see why org.slf4j.LoggerFactory got initialized use --trace-class-initialization=org.slf4j.LoggerFactory
```

 Explicitly initializing `org.slf4j.LoggerFactory` at image build time addresses this issue. 

Reference: https://www.graalvm.org/22.0/reference-manual/native-image/ClassInitialization/ 
