### PR TITLE
fix(java): initialize TestTag at build time

### DIFF
--- a/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-core/native-image.properties
+++ b/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-core/native-image.properties
@@ -1,7 +1,8 @@
 Args = --allow-incomplete-classpath \
 --enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt,\
-  org.slf4j.LoggerFactory \
+  org.slf4j.LoggerFactory,\
+  org.junit.platform.engine.TestTag \
 --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.SSL,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifier,\


### PR DESCRIPTION
This PR initializes `TestTag` as build time. 

Fixes #731 ☕️
