### PR TITLE
fix(java): initialize spanner test environment class at build-time and add reflection configurations

### DIFF
--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/clients/OpenCensusFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/clients/OpenCensusFeature.java
@@ -25,11 +25,15 @@ import org.graalvm.nativeimage.hosted.Feature;
 @AutomaticFeature
 final class OpenCensusFeature implements Feature {
 
-  private static final String OPEN_CENSUS_CLASS = "io.opencensus.impl.tags.TagsComponentImpl";
+  private static final String TAGS_COMPONENT_CLASS = "io.opencensus.impl.tags.TagsComponentImpl";
+  private static final String STATS_COMPONENT_CLASS = "io.opencensus.impl.stats.StatsComponentImpl";
 
   @Override
   public void beforeAnalysis(BeforeAnalysisAccess access) {
-    if (access.findClassByName(OPEN_CENSUS_CLASS) != null) {
+    if (access.findClassByName(STATS_COMPONENT_CLASS) != null) {
+      registerForReflectiveInstantiation(access, STATS_COMPONENT_CLASS);
+    }
+    if (access.findClassByName(TAGS_COMPONENT_CLASS) != null) {
       registerForReflectiveInstantiation(access, "io.opencensus.impl.metrics.MetricsComponentImpl");
       registerForReflectiveInstantiation(access, "io.opencensus.impl.tags.TagsComponentImpl");
       registerForReflectiveInstantiation(access, "io.opencensus.impl.trace.TraceComponentImpl");

--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/clients/SpannerFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/clients/SpannerFeature.java
@@ -27,9 +27,14 @@ import org.graalvm.nativeimage.hosted.Feature;
 final class SpannerFeature implements Feature {
 
   private static final String SPANNER_CLASS = "com.google.spanner.v1.SpannerGrpc";
+  private static final String SPANNER_TEST_CLASS = "com.google.cloud.spanner.GceTestEnvConfig";
 
   @Override
   public void beforeAnalysis(BeforeAnalysisAccess access) {
+    Class<?> spannerTestClass = access.findClassByName(SPANNER_TEST_CLASS);
+    if (spannerTestClass != null) {
+      NativeImageUtils.registerConstructorsForReflection(access, SPANNER_TEST_CLASS);
+    }
     Class<?> spannerClass = access.findClassByName(SPANNER_CLASS);
     if (spannerClass != null) {
       NativeImageUtils.registerClassHierarchyForReflection(

--- a/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-core/native-image.properties
+++ b/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-core/native-image.properties
@@ -2,7 +2,8 @@ Args = --allow-incomplete-classpath \
 --enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt,\
   org.slf4j.LoggerFactory,\
-  org.junit.platform.engine.TestTag \
+  org.junit.platform.engine.TestTag,\
+  com.google.cloud.spanner.IntegrationTestEnv \
 --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.SSL,\
     io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifier,\


### PR DESCRIPTION
This PR serves as follow up to https://github.com/googleapis/java-spanner/pull/1694 and aims to address https://github.com/googleapis/java-spanner/issues/1693

It also adds additional reflection configuration for `io.opencensus.impl.stats.StatsComponentImpl` and `com.google.cloud.spanner.GceTestEnvConfig`.




