### PR TITLE
fix(java): register test class for reflection to fix native image test

### DIFF
--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/clients/SpannerFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/clients/SpannerFeature.java
@@ -101,14 +101,16 @@ final class SpannerFeature implements Feature {
           "\\Qcom/google/cloud/spanner/connection/ITSqlScriptTest_TestQueryOptions.sql\\E");
     }
   }
-  private void registerSpannerTestClasses(BeforeAnalysisAccess access){
+
+  private void registerSpannerTestClasses(BeforeAnalysisAccess access) {
     Class<?> spannerTestClass = access.findClassByName(SPANNER_TEST_CLASS);
     if (spannerTestClass != null) {
       NativeImageUtils.registerConstructorsForReflection(access, SPANNER_TEST_CLASS);
     }
     Class<?> mockClass = access.findClassByName(MOCK_CLASS);
     if (mockClass != null) {
-      NativeImageUtils.registerClassForReflection(access, "com.google.cloud.spanner.MockDatabaseAdminServiceImpl$MockBackup");
+      NativeImageUtils.registerClassForReflection(
+          access, "com.google.cloud.spanner.MockDatabaseAdminServiceImpl$MockBackup");
     }
   }
 }

--- a/native-image-support/src/main/java/com/google/cloud/nativeimage/features/clients/SpannerFeature.java
+++ b/native-image-support/src/main/java/com/google/cloud/nativeimage/features/clients/SpannerFeature.java
@@ -29,6 +29,7 @@ final class SpannerFeature implements Feature {
 
   private static final String SPANNER_CLASS = "com.google.spanner.v1.SpannerGrpc";
   private static final String SPANNER_TEST_CLASS = "com.google.cloud.spanner.GceTestEnvConfig";
+  private static final String MOCK_CLASS = "com.google.cloud.spanner.MockDatabaseAdminServiceImpl";
   private static final String CLIENT_SIDE_IMPL_CLASS =
       "com.google.cloud.spanner.connection.ClientSideStatementImpl";
   private static final String CLIENT_SIDE_VALUE_CONVERTER =
@@ -50,10 +51,7 @@ final class SpannerFeature implements Feature {
 
   @Override
   public void beforeAnalysis(BeforeAnalysisAccess access) {
-    Class<?> spannerTestClass = access.findClassByName(SPANNER_TEST_CLASS);
-    if (spannerTestClass != null) {
-      NativeImageUtils.registerConstructorsForReflection(access, SPANNER_TEST_CLASS);
-    }
+    registerSpannerTestClasses(access);
     if (access.findClassByName(CLIENT_SIDE_IMPL_CLASS) != null) {
       NativeImageUtils.registerClassHierarchyForReflection(access, CLIENT_SIDE_IMPL_CLASS);
     }
@@ -101,6 +99,16 @@ final class SpannerFeature implements Feature {
       resourcesRegistry.addResources(
           ConfigurationCondition.alwaysTrue(),
           "\\Qcom/google/cloud/spanner/connection/ITSqlScriptTest_TestQueryOptions.sql\\E");
+    }
+  }
+  private void registerSpannerTestClasses(BeforeAnalysisAccess access){
+    Class<?> spannerTestClass = access.findClassByName(SPANNER_TEST_CLASS);
+    if (spannerTestClass != null) {
+      NativeImageUtils.registerConstructorsForReflection(access, SPANNER_TEST_CLASS);
+    }
+    Class<?> mockClass = access.findClassByName(MOCK_CLASS);
+    if (mockClass != null) {
+      NativeImageUtils.registerClassForReflection(access, "com.google.cloud.spanner.MockDatabaseAdminServiceImpl$MockBackup");
     }
   }
 }


### PR DESCRIPTION
Running `mvn test -Dtest=com.google.cloud.spanner.DatabaseAdminClientTest -Pnative -DfailIfNoTests=false` locally in java-spanner results in the following error message:

```
 com.google.cloud.spanner.SpannerException: UNKNOWN: com.google.api.gax.rpc.UnknownException: io.grpc.StatusRuntimeException: UNKNOWN
       com.google.cloud.spanner.SpannerExceptionFactory.newSpannerExceptionPreformatted(SpannerExceptionFactory.java:284)
       com.google.cloud.spanner.SpannerExceptionFactory.newSpannerException(SpannerExceptionFactory.java:61)
       com.google.cloud.spanner.SpannerExceptionFactory.newSpannerException(SpannerExceptionFactory.java:181)
       com.google.cloud.spanner.spi.v1.GapicSpannerRpc.get(GapicSpannerRpc.java:1682)
       com.google.cloud.spanner.spi.v1.GapicSpannerRpc.lambda$listBackups$5(GapicSpannerRpc.java:1021)
       [...]
     Caused by: java.util.concurrent.ExecutionException: com.google.api.gax.rpc.UnknownException: io.grpc.StatusRuntimeException: UNKNOWN
       com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:588)
       com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:567)
       com.google.cloud.spanner.spi.v1.GapicSpannerRpc.get(GapicSpannerRpc.java:1676)
       [...]
     Caused by: com.google.api.gax.rpc.UnknownException: io.grpc.StatusRuntimeException: UNKNOWN
       com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:75)
       com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:72)
       com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:60)
       com.google.api.gax.grpc.GrpcExceptionCallable$ExceptionTransformingFuture.onFailure(GrpcExceptionCallable.java:97)
       com.google.api.core.ApiFutures$1.onFailure(ApiFutures.java:68)
       [...]
     Caused by: io.grpc.StatusRuntimeException: UNKNOWN
       io.grpc.Status.asRuntimeException(Status.java:535)
       [...]
```

Digging through the stacktrace revealed that an inner class of `com.google.cloud.spanner.MockDatabaseAdminServiceImpl` wasn't accessible to the native image builder. This resulted in an Exception being thrown when `(String) obj.getClass().getMethod("getName")` was called here:

https://github.com/googleapis/java-spanner/blob/7de41bf96ceebe45663d07c4416c488ad4f54832/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockDatabaseAdminServiceImpl.java#L588 

cc @meltsufin 
