### PR TITLE
feat: remove native-image.properties settings after relocation

### DIFF
--- a/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-core/native-image.properties
+++ b/native-image-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-core/native-image.properties
@@ -1,17 +1,2 @@
-Args = --allow-incomplete-classpath \
---enable-url-protocols=https,http \
---initialize-at-build-time=org.conscrypt,\
-  org.slf4j.LoggerFactory,\
-  org.junit.platform.engine.TestTag,\
-  com.google.cloud.spanner.IntegrationTestEnv \
---initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl,\
-    io.grpc.netty.shaded.io.netty.internal.tcnative.SSL,\
-    io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifier,\
-    io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethod,\
-    io.grpc.netty.shaded.io.netty.internal.tcnative.AsyncSSLPrivateKeyMethod,\
-    io.grpc.netty.shaded.io.grpc.netty,\
-    io.grpc.netty.shaded.io.netty.channel.epoll,\
-    io.grpc.netty.shaded.io.netty.channel.unix,\
-    io.grpc.netty.shaded.io.netty.handler.ssl,\
-    io.grpc.internal.RetriableStream,\
-    com.google.cloud.firestore.FirestoreImpl
+Args = --initialize-at-build-time=com.google.cloud.spanner.IntegrationTestEnv \
+--initialize-at-run-time=com.google.cloud.firestore.FirestoreImpl


### PR DESCRIPTION
These settings have been relocated to GAX. See https://github.com/googleapis/gax-java/blob/main/gax/src/main/resources/META-INF/native-image/com.google.api/gax/native-image.properties and https://github.com/googleapis/gax-java/blob/main/gax-grpc/src/main/resources/META-INF/native-image/com.google.api/gax-grpc/native-image.properties