### PR TITLE
chore: remove native-image-support from bom

### DIFF
--- a/google-cloud-core-bom/pom.xml
+++ b/google-cloud-core-bom/pom.xml
@@ -75,11 +75,6 @@
         <artifactId>google-cloud-core-http</artifactId>
         <version>2.7.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-core:current} -->
       </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>native-image-support</artifactId>
-        <version>0.14.0</version><!-- {x-version-update:native-image-support:current} -->
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The module itself has been removed in #820.