### PR TITLE
fix: make title and description of Condition Nullable

### DIFF
--- a/google-cloud-core/src/main/java/com/google/cloud/Condition.java
+++ b/google-cloud-core/src/main/java/com/google/cloud/Condition.java
@@ -18,6 +18,7 @@ package com.google.cloud;
 
 import com.google.api.core.BetaApi;
 import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 
 /**
  * Class for Identity and Access Management (IAM) policies. IAM policies are used to specify access
@@ -32,9 +33,11 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 public abstract class Condition {
   /** Get IAM Policy Binding Condition Title */
+  @Nullable
   public abstract String getTitle();
 
   /** Get IAM Policy Binding Condition Description */
+  @Nullable
   public abstract String getDescription();
 
   /** Get IAM Policy Binding Condition Expression */
@@ -51,10 +54,10 @@ public abstract class Condition {
   @AutoValue.Builder
   public abstract static class Builder {
     /** Set IAM Policy Binding Condition Title */
-    public abstract Builder setTitle(String title);
+    public abstract Builder setTitle(@Nullable String title);
 
     /** Set IAM Policy Binding Condition Description */
-    public abstract Builder setDescription(String description);
+    public abstract Builder setDescription(@Nullable String description);
 
     /** Set IAM Policy Binding Condition Expression */
     public abstract Builder setExpression(String expression);

--- a/google-cloud-core/src/test/java/com/google/cloud/ConditionTest.java
+++ b/google-cloud-core/src/test/java/com/google/cloud/ConditionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public final class ConditionTest {
+
+  @Test
+  public void title_nullable() {
+    Condition condition =
+        Condition.newBuilder().setTitle(null).setDescription("desc").setExpression("expr").build();
+
+    assertThat(condition.getTitle()).isNull();
+  }
+
+  @Test
+  public void description_nullable() {
+    Condition condition =
+        Condition.newBuilder().setTitle("title").setDescription(null).setExpression("expr").build();
+
+    assertThat(condition.getDescription()).isNull();
+  }
+}


### PR DESCRIPTION
According to https://cloud.google.com/iam/docs/conditions-overview#syntax_overview both title and description are optional.

Currently, AutoValue treats these fields as non-null which goes against the definition from the API.

This change may be considered breaking by some criteria, however this class is annotated @BetaApi.

