### PR TITLE
Only try find project ID if its required

### DIFF
--- a/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
+++ b/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
@@ -299,8 +299,8 @@ public abstract class ServiceOptions<
       Class<? extends ServiceRpcFactory<OptionsT>> rpcFactoryClass,
       Builder<ServiceT, OptionsT, ?> builder,
       ServiceDefaults<ServiceT, OptionsT> serviceDefaults) {
-    projectId = builder.projectId != null ? builder.projectId : getDefaultProject();
     if (projectIdRequired()) {
+      projectId = builder.projectId != null ? builder.projectId : getDefaultProject();
       checkArgument(
           projectId != null,
           "A project ID is required for this service but could not be determined from the builder "


### PR DESCRIPTION
The client shouldn't try get the project ID unless its required. In environments where the metadata service is not present AND the project ID is not required, this just results in needless errors that sometimes show up in firewall logs.

:bus: In January 2023, this library has moved to
[google-cloud-java/java-core](
https://github.com/googleapis/google-cloud-java/tree/main/java-core).
This repository will be archived in the future.

